### PR TITLE
Use Travis container based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
 language: csharp
 mono: alpha
 solution: MdSharp.sln
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y nodejs
-install:
-  - npm install
+
 script:
   - gulp test
+
+cache:
+  directories:
+  - $HOME/node_modules
+  - bin
+  - packages
+addons:
+  apt:
+    packages:
+      - nodejs
+install:
+  - npm install
+
+# Use container based infrastructure.
+sudo: false


### PR DESCRIPTION
# Caching dependencies FTW!
I think this is going to speed up our CI builds by caching:
- npm packages
- nuget.exe (script won't redownload if it already exists)
- nuget packages
  - I'm not sure about this one, but package restore should update out-of-date stuff, right?
